### PR TITLE
Changes from background agent bc-539ce6ed-13b8-4a8f-a847-209ce2873f5f

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,7 +8,7 @@ android:
   manifest:
     package: app.polarbear
     sdk:
-      min_sdk_version: 21
+      min_sdk_version: 23
       target_sdk_version: 33
     application:
       label: "Local Desktop"


### PR DESCRIPTION
Increase Android `min_sdk_version` to 23 to resolve `UnsatisfiedLinkError` due to missing native API.

The native library `liblocaldesktop.so` uses `AMotionEvent_getActionButton`, which was introduced in Android API level 23. The previous `min_sdk_version` of 21 allowed the app to be installed on older Android versions (5.0-5.1) that do not support this function, leading to a `java.lang.UnsatisfiedLinkError` crash on startup. Updating the `min_sdk_version` ensures the app is only installed on compatible devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-539ce6ed-13b8-4a8f-a847-209ce2873f5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-539ce6ed-13b8-4a8f-a847-209ce2873f5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

